### PR TITLE
회원가입 코드를 미들웨어로 분산  유효성검사->중복검사->엔티티의 유효성검사->회원가입 진행

### DIFF
--- a/src/auth/middleWare/joinDataConfirm.middleWare.ts
+++ b/src/auth/middleWare/joinDataConfirm.middleWare.ts
@@ -1,0 +1,36 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { NextFunction, Request, Response } from 'express';
+
+@Injectable()
+export class JoinDataConfirmMiddleWare implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction) {
+    const data = req.body;
+    if (!data.socialId && !data.email) {
+      return res.json({
+        ok: false,
+        error: '소셜로그인 또는 회원가입을 하세요',
+      });
+    }
+
+    if (!data.nickName) {
+      return res.json({
+        ok: false,
+        error: '닉네임을 입력하세요.',
+      });
+    }
+
+    if (data.email && !data.socialId) {
+      if (!data.pwd || !data.pwdConfirm) {
+        return res.json({
+          ok: false,
+          error: '비밀번호나 비밀번호 확인란을 입력하세요',
+        });
+      }
+
+      if (data.pwd !== data.pwdConfirm) {
+        return res.json({ ok: false, error: '비밀번호가 일치하지 않습니다.' });
+      }
+    }
+    return next();
+  }
+}

--- a/src/auth/middleWare/joinExistConfirm.middleWare.ts
+++ b/src/auth/middleWare/joinExistConfirm.middleWare.ts
@@ -1,0 +1,44 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { json, NextFunction, Request, Response } from 'express';
+import { commonMessages } from 'src/common/erroeMessages';
+import { JoinDTO } from 'src/user/dtos/join.dto';
+import { UserService } from 'src/user/user.service';
+import { AuthService } from '../auth.service';
+
+@Injectable()
+export class JoinExistConfirmMiddleWare implements NestMiddleware {
+  constructor(
+    private readonly userService: UserService,
+    private readonly authService: AuthService,
+  ) {}
+
+  async use(req: Request, res: Response, next: NextFunction) {
+    const data: JoinDTO = req.body;
+
+    try {
+      for (let item in data) {
+        if (
+          item === 'pwd' ||
+          item === 'pwdConfirm' ||
+          item === 'socialId' ||
+          item === 'change'
+        )
+          continue;
+        const exist = await this.userService.findByCondition({
+          [item]: data[item],
+        });
+        if (exist) return res.json(commonMessages.commonExist(item));
+      }
+
+      if ('change' in data) {
+        delete data['change'];
+        await this.userService.registerUser(data);
+        return res.json({ ok: true });
+      }
+      return next();
+    } catch (e) {
+      console.log(e);
+      return res.json(commonMessages.commonFail('인증이'));
+    }
+  }
+}

--- a/src/auth/middleWare/joinSocialLogin.middleWare.ts
+++ b/src/auth/middleWare/joinSocialLogin.middleWare.ts
@@ -1,0 +1,67 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { NextFunction, Request, Response } from 'express';
+import { commonMessages } from 'src/common/erroeMessages';
+import { UserService } from 'src/user/user.service';
+import { AuthService } from '../auth.service';
+
+@Injectable()
+export class SocialLoginMiddleWare implements NestMiddleware {
+  constructor(
+    private readonly userService: UserService,
+    private readonly authService: AuthService,
+  ) {}
+  async use(req: Request, res: Response, next: NextFunction) {
+    const data = req.body;
+    try {
+      if ('socialId' in data) {
+        const after = [];
+        const before = [];
+        console.log(before);
+
+        let exist = await this.userService.findByCondition({
+          socialId: data.socialId,
+        });
+
+        if (exist) {
+          for (let i in data) {
+            if (data[i] !== exist[i]) {
+              after.push({ [i]: data[i] });
+              before.push({ [i]: exist[i] || '입력안됨' });
+            }
+          }
+        }
+
+        if (!exist) {
+          exist = await this.userService.registerUser(data);
+        }
+
+        const activeToken = this.authService.sign(
+          'nickName',
+          exist.nickName,
+          60 * 60,
+        );
+        const refreshToken = this.authService.sign(
+          'id',
+          exist.id,
+          60 * 60 * 24 * 7,
+        );
+
+        return res.json({
+          ok: true,
+          ...(after.length > 0 && {
+            before,
+            after,
+            message: '회원정보가 변경됩니다. 변경하겠습니까?',
+          }),
+
+          activeToken,
+          refreshToken,
+        });
+      }
+      return next();
+    } catch (e) {
+      console.log(e);
+      return res.json(commonMessages.commonFail('인증이'));
+    }
+  }
+}

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -23,6 +23,25 @@ export class UserService {
     @InjectRepository(Auth) private readonly auth: Repository<Auth>,
   ) {}
 
+  async join(data: JoinDTO): Promise<JoinOutput> {
+    try {
+      const newUser = await this.registerUser(data);
+      if (newUser.email) {
+        const verify = await this.authService.makeVerifyCode(newUser);
+        await this.authService.sendMail(newUser.email, verify.code);
+      }
+      return {
+        ok: true,
+        ...(data.email && {
+          message: '가입한 이메일로 인증번호가 발송되었습니다.',
+        }),
+      };
+    } catch (e) {
+      console.log(e);
+      return commonMessages.commonFail('회원가입이');
+    }
+  }
+
   async login({ email, pwd }: LoginDTO) {
     try {
       const userExist = await this.user.findOne(


### PR DESCRIPTION
##안녕하세요!! 

1.  회원가입 기능을 최대한 나누었습니다.
2. 미들웨어에서 유효성검사, 중복검사를 진행하고
3. DTO를 통해서 에서 다시 유효성 검사가 진행됩니다.
4. 검사가 모두 통과하면 회원가입이 진행됩니다.

##질문 드릴 내용은.

1. 미들웨어로 나누는 방법이 괜찮은지 궁금합니다. (소셜계정으로 회원가입가입, 일반 회원가입, 소셜로그인) 3가지 중복되는 회원가입 
   기능을 모두 소화하려다 보니 미들웨어를 3개로 나누었는데 성능부분에서 문제가 될 수도 있는지 궁금합니다.

2. 회원가입을 끝내면 이메일을 발송합니다.  그리고 응답을 하는데 이렇게 하니까 반응시간이 느려졌습니다.
    제가 해결하려고 고민한 방법은 
> 1. 미리 응답을 해버리고 이메일은 보내는 방법과 
> 2. 나중에 시간이 된다면 redis를 이용해서 해결하려고 합니다.
    혹시 좀더 괜찮은 방법이 있는지 궁금합니다.

날씨가 아직 덥습니다. 이번주는 비가 많이 온다고 하는데 건강 유의하시고,
항상 감사힙니다.